### PR TITLE
chore: Add github-actions ecosystem to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,11 @@ updates:
   - dependency-name: org.apache.maven.plugins:maven-checkstyle-plugin
     versions:
     - 3.1.1
+
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: sunday
+    time: "04:00"
+  open-pull-requests-limit: 99


### PR DESCRIPTION
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/

