### PR TITLE
chore: Better Workflow Action Permissions (fixes #791)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,13 +8,15 @@ on:
     branches: [main]
 
 permissions:
-  # maven-dependency-submission-action needs write
-  contents: write
+  contents: read
 
 jobs:
   testOnLinux:
     name: Maven Verify (Build & Test) on Linux
     runs-on: ubuntu-latest
+    permissions:
+      # maven-dependency-submission-action needs write
+      contents: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1


### PR DESCRIPTION
Folow up to #792 for #791 with a slightly better configuration.

This might address the pending Token-Permissions Code scanning Vulnerability alert Reporting (which also affects the OpenSSF Scorecard Report).