### PR TITLE
fix: Upgrade ch.vorburger.exec from 3.1.5 to 3.2.0

### DIFF
--- a/mariaDB4j-core/pom.xml
+++ b/mariaDB4j-core/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>ch.vorburger.exec</groupId>
       <artifactId>exec</artifactId>
-      <version>3.1.5</version>
+      <version>3.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
See https://github.com/vorburger/ch.vorburger.exec/compare/exec-3.1.5...exec-3.2.0 for the "release notes" of what all this changes. The most important one is that this fixes https://github.com/vorburger/ch.vorburger.exec/issues/9.