### PR TITLE
Run unit tests on ubuntu-24.04

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   testOnLinux:
     name: Maven Verify (Build & Test) on Linux
-    runs-on: ubuntu-22.04 # 24.04 is causing https://github.com/MariaDB4j/MariaDB4j/issues/1045
+    runs-on: ubuntu-24.04
     permissions:
       # maven-dependency-submission-action needs write
       contents: write


### PR DESCRIPTION
libncurses5 issue was solved already

References: https://github.com/MariaDB4j/MariaDB4j/issues/1045