### PR TITLE
dev: DevContainer with Java 17 (instead of 11) 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+  // https://hub.docker.com/r/microsoft/devcontainers-java
+  "image": "mcr.microsoft.com/devcontainers/java:17",
+  "features": {
+     "ghcr.io/devcontainers/features/java:1": {
+        "version": "none",
+        "installGradle": "false",
+        "installMaven": "true"
+    }
+  }
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,10 @@ updates:
     day: sunday
     time: "04:00"
   open-pull-requests-limit: 99
+
+- package-ecosystem: "devcontainers"
+  directory: "/"
+  schedule:
+    interval: monthly
+    day: sunday
+    time: "04:00"


### PR DESCRIPTION
To be able to [more easily] use (e.g.) GitHub Codespaces.