### PR TITLE
test: Include a method for cross-platform tests

### DIFF
--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/Platform.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/Platform.java
@@ -1,0 +1,55 @@
+/*
+ * #%L
+ * MariaDB4j
+ * %%
+ * Copyright (C) 2025 Michael Vorburger
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ch.vorburger.mariadb4j;
+
+import org.apache.commons.lang3.SystemUtils;
+
+/**
+ * OS Detector.
+ *
+ * <p>Includes a method for cross-platform tests to temporarily override OS to simulate running on another one.</p>
+ *
+ * @author <a href="https://www.vorburger.ch/">Michael Vorburger.ch</a>
+ */
+/* Intentionally package private, not public */
+final class Platform implements AutoCloseable {
+
+    enum OS { LINUX, MAC, WINDOWS }
+
+    // TODO Introduce OTHER instead of falling back to LINUX
+    private static final OS real = SystemUtils.IS_OS_WINDOWS ? OS.WINDOWS : SystemUtils.IS_OS_MAC ? OS.MAC : OS.LINUX;
+
+    private static OS simulated = real;
+
+    static OS get() {
+        return simulated;
+    }
+
+    // https://errorprone.info/bugpattern/StaticAssignmentInConstructor
+    @SuppressWarnings("StaticAssignmentInConstructor")
+    Platform(OS simulated) {
+        Platform.simulated = simulated;
+    }
+
+    @Override
+    public void close() {
+        simulated = real;
+    }
+}

--- a/mariaDB4j-core/src/test/java/ch/vorburger/mariadb4j/tests/DBConfigurationBuilderTest.java
+++ b/mariaDB4j-core/src/test/java/ch/vorburger/mariadb4j/tests/DBConfigurationBuilderTest.java
@@ -36,7 +36,8 @@ import org.junit.Test;
 
 public class DBConfigurationBuilderTest {
 
-    @Test public void defaultDataDirIsTemporaryAndIncludesPortNumber() {
+    @Test
+    public void defaultDataDirIsTemporaryAndIncludesPortNumber() {
         DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
         DBConfiguration config = builder.build();
         String defaultDataDir = config.getDataDir();
@@ -45,7 +46,8 @@ public class DBConfigurationBuilderTest {
         assertTrue(defaultDataDir.contains(Integer.toString(port)));
     }
 
-    @Test public void defaultDataDirIsTemporaryAndIncludesPortNumberEvenIfPortIsExplicitlySet() {
+    @Test
+    public void defaultDataDirIsTemporaryAndIncludesPortNumberEvenIfPortIsExplicitlySet() {
         DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
         builder.setPort(12345);
         DBConfiguration config = builder.build();
@@ -54,7 +56,8 @@ public class DBConfigurationBuilderTest {
         assertTrue(defaultDataDir.contains(Integer.toString(12345)));
     }
 
-    @Test public void dataDirDoesNotIncludePortNumberEvenItsExplicitlySet() {
+    @Test
+    public void dataDirDoesNotIncludePortNumberEvenItsExplicitlySet() {
         DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
         builder.setDataDir("db/data");
         DBConfiguration config = builder.build();
@@ -63,7 +66,8 @@ public class DBConfigurationBuilderTest {
         assertFalse(Util.isTemporaryDirectory(defaultDataDir));
     }
 
-    @Test public void resetDataDirToDefaultTemporary() {
+    @Test
+    public void resetDataDirToDefaultTemporary() {
         DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
         builder.setDataDir("db/data");
         assertEquals("db/data", builder.getDataDir());
@@ -78,7 +82,8 @@ public class DBConfigurationBuilderTest {
         assertTrue(defaultDataDir.contains(Integer.toString(port)));
     }
 
-    @Test public void defaultTmpDirIsTemporaryAndIncludesPortNumber() {
+    @Test
+    public void defaultTmpDirIsTemporaryAndIncludesPortNumber() {
         DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
         DBConfiguration config = builder.build();
         String defaultTmpDir = config.getTmpDir();
@@ -87,7 +92,8 @@ public class DBConfigurationBuilderTest {
         assertTrue(defaultTmpDir.contains(Integer.toString(port)));
     }
 
-    @Test public void defaultTmpDirIsTemporaryAndIncludesPortNumberEvenIfPortIsExplicitlySet() {
+    @Test
+    public void defaultTmpDirIsTemporaryAndIncludesPortNumberEvenIfPortIsExplicitlySet() {
         DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
         builder.setPort(12345);
         DBConfiguration config = builder.build();
@@ -96,7 +102,8 @@ public class DBConfigurationBuilderTest {
         assertTrue(defaultTmpDir.contains(Integer.toString(12345)));
     }
 
-    @Test public void tmpDirDoesNotIncludePortNumberEvenItsExplicitlySet() {
+    @Test
+    public void tmpDirDoesNotIncludePortNumberEvenItsExplicitlySet() {
         DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
         builder.setTmpDir("db/tmp");
         DBConfiguration config = builder.build();
@@ -105,7 +112,8 @@ public class DBConfigurationBuilderTest {
         assertFalse(Util.isTemporaryDirectory(defaultTmpDir));
     }
 
-    @Test public void resetTmpDirToDefaultTemporary() {
+    @Test
+    public void resetTmpDirToDefaultTemporary() {
         DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
         builder.setTmpDir("db/tmp");
         assertEquals("db/tmp", builder.getTmpDir());
@@ -120,7 +128,8 @@ public class DBConfigurationBuilderTest {
         assertTrue(defaultTmpDir.contains(Integer.toString(port)));
     }
 
-    @Test public void defaultLibDirIsRelativeToBaseDir() {
+    @Test
+    public void defaultLibDirIsRelativeToBaseDir() {
         DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
         DBConfiguration config = builder.build();
         String defaultBaseDir = config.getBaseDir();
@@ -129,7 +138,8 @@ public class DBConfigurationBuilderTest {
         assertEquals(defaultLibDir, defaultBaseDir + "/libs");
     }
 
-    @Test public void defaultLibDirIsRelativeToUpdatedBaseDir() throws IOException {
+    @Test
+    public void defaultLibDirIsRelativeToUpdatedBaseDir() throws IOException {
         DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
         Path baseDir = Files.createTempDirectory("mariadb");
         builder.setBaseDir(baseDir.toAbsolutePath().toString());
@@ -139,7 +149,8 @@ public class DBConfigurationBuilderTest {
         assertEquals(defaultLibDir, baseDir + "/libs");
     }
 
-    @Test public void modifiedLibDir() throws IOException {
+    @Test
+    public void modifiedLibDir() throws IOException {
         DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
         Path libDir = Files.createTempDirectory("libsdir");
         builder.setLibDir(libDir.toAbsolutePath().toString());
@@ -151,20 +162,23 @@ public class DBConfigurationBuilderTest {
         assertEquals(updatedLibDir, libDir.toAbsolutePath().toString());
     }
 
-    @Test public void deletesTemporaryDirectoriesAsDefault() {
+    @Test
+    public void deletesTemporaryDirectoriesAsDefault() {
         DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
         DBConfiguration config = builder.build();
         assertTrue(config.isDeletingTemporaryBaseAndDataDirsOnShutdown());
     }
 
-    @Test public void keepsTemporaryDirectories() {
+    @Test
+    public void keepsTemporaryDirectories() {
         DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
         builder.setDeletingTemporaryBaseAndDataDirsOnShutdown(false);
         DBConfiguration config = builder.build();
         assertFalse(config.isDeletingTemporaryBaseAndDataDirsOnShutdown());
     }
 
-    @Test public void defaultCharacterSet() {
+    @Test
+    public void defaultCharacterSet() {
         DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
         String character = "utf8mb4";
         builder.setDefaultCharacterSet(character);
@@ -173,22 +187,27 @@ public class DBConfigurationBuilderTest {
         assertEquals(character, defaultCharacterSet);
     }
 
-    @Test public void defaultCharacterSetIsEmpty() {
+    @Test
+    public void defaultCharacterSetIsEmpty() {
         DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
         DBConfiguration config = builder.build();
         String defaultCharacterSet = config.getDefaultCharacterSet();
         assertNull(defaultCharacterSet);
     }
 
-    @Test public void defaultExecutables() {
+    @Test
+    public void defaultExecutables() {
         DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
         DBConfiguration config = builder.build();
         var pathSeparator = System.getProperty("file.separator");
-        var expectedString = "MariaDB4j/base/bin/mariadbd".replace("/", pathSeparator);
-        assertTrue(config.getExecutable(Executable.Server).toString().contains(expectedString));
+        var expectedMariaDBString = "MariaDB4j/base/bin/mariadbd".replace("/", pathSeparator);
+        var expectedMySqlString = "MariaDB4j/base/bin/mysqld".replace("/", pathSeparator);
+        String executable = config.getExecutable(Executable.Server).toString();
+        assertTrue(executable.contains(expectedMariaDBString) || executable.contains(expectedMySqlString));
     }
 
-    @Test public void customExecutables() {
+    @Test
+    public void customExecutables() {
         DBConfigurationBuilder builder = DBConfigurationBuilder.newBuilder();
         builder.setExecutable(Executable.Server, "/usr/sbin/mariadbd");
         DBConfiguration config = builder.build();

--- a/mariaDB4j/src/test/java/ch/vorburger/mariadb4j/StartSimulatedForAllPlatformsTest.java
+++ b/mariaDB4j/src/test/java/ch/vorburger/mariadb4j/StartSimulatedForAllPlatformsTest.java
@@ -39,17 +39,25 @@ import org.junit.Test;
  */
 public class StartSimulatedForAllPlatformsTest {
 
+    @SuppressWarnings("try") // TODO Replace platform with _ when Java 22+
     @Test public void simulatedStartWin64() throws Exception {
-        checkPlatformStart(DBConfigurationBuilder.WINX64);
+        try (var platform = new Platform(Platform.OS.WINDOWS)) {
+            checkPlatformStart(DBConfigurationBuilder.WINX64);
+        }
     }
 
+    @SuppressWarnings("try") // TODO Replace platform with _ when Java 22+
     @Test public void simulatedStartLinux() throws Exception {
-        checkPlatformStart(DBConfigurationBuilder.LINUX);
+        try (var platform = new Platform(Platform.OS.LINUX)) {
+            checkPlatformStart(DBConfigurationBuilder.LINUX);
+        }
     }
 
-    @Ignore // TODO https://github.com/MariaDB4j/MariaDB4j/issues/497
+    @SuppressWarnings("try") // TODO Replace platform with _ when Java 22+
     @Test public void simulatedStartOSX() throws Exception {
-        checkPlatformStart(DBConfigurationBuilder.OSX);
+        try (var platform = new Platform(Platform.OS.MAC)) {
+            checkPlatformStart(DBConfigurationBuilder.OSX);
+        }
     }
 
     void checkPlatformStart(String platform) throws ManagedProcessException, IOException {


### PR DESCRIPTION
To temporarily override OS to simulate running on another one.

Originally motivated by exploring https://github.com/MariaDB4j/MariaDB4j/pull/1126/files#r2019771660 in #1134,

but now separately committing this as-is already (because that still does not quite work).