### PR TITLE
(Fix) AssertionError: expected:<5678> but was:<49961> at ch.vorburger.mariadb4j.tests.springframework.*

### DIFF
--- a/mariaDB4j-springboot/pom.xml
+++ b/mariaDB4j-springboot/pom.xml
@@ -37,4 +37,21 @@
         <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.3</version>
+        <configuration>
+          <includes>
+            <include>**/*Test.java</include>
+          </includes>
+          <excludes>
+            <exclude>**/*Abstract*.java</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/mariaDB4j-springboot/src/test/java/ch/vorburger/mariadb4j/tests/springframework/MariaDB4jSpringServiceNewDefaultsOverriddenBySpringValueTest.java
+++ b/mariaDB4j-springboot/src/test/java/ch/vorburger/mariadb4j/tests/springframework/MariaDB4jSpringServiceNewDefaultsOverriddenBySpringValueTest.java
@@ -23,15 +23,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import ch.vorburger.mariadb4j.springframework.MariaDB4jSpringService;
 
-import org.junit.Ignore;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
-import java.util.Properties;
 
 /**
  * Tests overriding the default configuration of a MariaDB4jSpringService set in a {@link
@@ -39,29 +39,29 @@ import java.util.Properties;
  *
  * @author Michael Vorburger
  */
-@ContextConfiguration
+@ContextConfiguration(classes = MariaDB4jSpringServiceTestSpringConfiguration.class)
 @RunWith(SpringJUnit4ClassRunner.class)
+@TestPropertySource(properties = {MariaDB4jSpringService.PORT + "=5678"})
 public class MariaDB4jSpringServiceNewDefaultsOverriddenBySpringValueTest {
-
-    @Configuration
-    public static class TestConfiguration extends MariaDB4jSpringServiceTestSpringConfiguration {
-
-        @Override
-        protected void configureMariaDB4jSpringService(MariaDB4jSpringService s) {
-            s.setDefaultPort(1234);
-        }
-
-        @Override
-        protected void configureProperties(Properties properties) {
-            properties.setProperty(MariaDB4jSpringService.PORT, "5678");
-        }
-    }
 
     @Autowired MariaDB4jSpringService s;
 
+    @Before
+    public void setUp() {
+        if (!s.isRunning()) {
+            s.start(); // Only start if not already running
+        }
+    }
+
     @Test
-    @Ignore // TODO https://github.com/MariaDB4j/MariaDB4j/issues/1150
     public void testNewDefaults() {
         assertEquals(5678, s.getConfiguration().getPort());
+    }
+
+    @After
+    public void tearDown() {
+        if (s.isRunning()) {
+            s.stop();
+        }
     }
 }

--- a/mariaDB4j-springboot/src/test/java/ch/vorburger/mariadb4j/tests/springframework/MariaDB4jSpringServiceOverrideBySpringValueTest.java
+++ b/mariaDB4j-springboot/src/test/java/ch/vorburger/mariadb4j/tests/springframework/MariaDB4jSpringServiceOverrideBySpringValueTest.java
@@ -23,49 +23,46 @@ import static org.junit.Assert.assertEquals;
 
 import ch.vorburger.mariadb4j.springframework.MariaDB4jSpringService;
 
-import org.junit.Ignore;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
-import java.util.Properties;
 
 /**
  * Tests setting the configuration of a MariaDB4jSpringService via Spring Value properties.
  *
  * @author Michael Vorburger
  */
-@ContextConfiguration
+@ContextConfiguration(classes = MariaDB4jSpringServiceTestSpringConfiguration.class)
 @RunWith(SpringJUnit4ClassRunner.class)
+@TestPropertySource(
+        properties = {
+            MariaDB4jSpringService.PORT + "=5679",
+            MariaDB4jSpringService.BASE_DIR
+                    + "=target/MariaDB4jSpringServiceOverrideBySpringValueTest/baseDir",
+            MariaDB4jSpringService.LIB_DIR
+                    + "=target/MariaDB4jSpringServiceOverrideBySpringValueTest/baseDir/libs",
+            MariaDB4jSpringService.DATA_DIR
+                    + "=target/MariaDB4jSpringServiceOverrideBySpringValueTest/dataDir",
+            MariaDB4jSpringService.TMP_DIR
+                    + "=target/MariaDB4jSpringServiceOverrideBySpringValueTest/tmpDir"
+        })
 public class MariaDB4jSpringServiceOverrideBySpringValueTest {
-
-    @Configuration
-    public static class TestConfiguration extends MariaDB4jSpringServiceTestSpringConfiguration {
-        @Override
-        protected void configureProperties(Properties properties) {
-            properties.setProperty(MariaDB4jSpringService.PORT, "5679");
-            properties.setProperty(
-                    MariaDB4jSpringService.BASE_DIR,
-                    "target/MariaDB4jSpringServiceOverrideBySpringValueTest/baseDir");
-            properties.setProperty(
-                    MariaDB4jSpringService.LIB_DIR,
-                    "target/MariaDB4jSpringServiceOverrideBySpringValueTest/baseDir/libs");
-            properties.setProperty(
-                    MariaDB4jSpringService.DATA_DIR,
-                    "target/MariaDB4jSpringServiceOverrideBySpringValueTest/dataDir");
-            properties.setProperty(
-                    MariaDB4jSpringService.TMP_DIR,
-                    "target/MariaDB4jSpringServiceOverrideBySpringValueTest/tmpDir");
-        }
-    }
 
     @Autowired MariaDB4jSpringService s;
 
+    @Before
+    public void setUp() {
+        if (!s.isRunning()) {
+            s.start(); // Only start if not already running
+        }
+    }
+
     @Test
-    @Ignore // TODO https://github.com/MariaDB4j/MariaDB4j/issues/1150
     public void testOverrideBySpringValue() {
         assertEquals(5679, s.getConfiguration().getPort());
         assertEquals(
@@ -80,5 +77,12 @@ public class MariaDB4jSpringServiceOverrideBySpringValueTest {
         assertEquals(
                 "target/MariaDB4jSpringServiceOverrideBySpringValueTest/tmpDir",
                 s.getConfiguration().getTmpDir());
+    }
+
+    @After
+    public void tearDown() {
+        if (s.isRunning()) {
+            s.stop();
+        }
     }
 }

--- a/mariaDB4j-springboot/src/test/java/ch/vorburger/mariadb4j/tests/springframework/MariaDB4jSpringServiceStandardDefaultsTest.java
+++ b/mariaDB4j-springboot/src/test/java/ch/vorburger/mariadb4j/tests/springframework/MariaDB4jSpringServiceStandardDefaultsTest.java
@@ -22,7 +22,9 @@ package ch.vorburger.mariadb4j.tests.springframework;
 import ch.vorburger.mariadb4j.springframework.MariaDB4jSpringService;
 
 import org.apache.commons.lang3.SystemUtils;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,11 +42,25 @@ public class MariaDB4jSpringServiceStandardDefaultsTest {
 
     @Autowired MariaDB4jSpringService s;
 
+    @Before
+    public void setUp() {
+        if (!s.isRunning()) {
+            s.start(); // Only start if not already running
+        }
+    }
+
     @Test
     public void testStandardDefaults() {
         Assert.assertNotEquals(3306, s.getConfiguration().getPort());
         Assert.assertTrue(s.getConfiguration().getBaseDir().contains(SystemUtils.JAVA_IO_TMPDIR));
         Assert.assertTrue(s.getConfiguration().getDataDir().contains(SystemUtils.JAVA_IO_TMPDIR));
         Assert.assertTrue(s.getConfiguration().getTmpDir().contains(SystemUtils.JAVA_IO_TMPDIR));
+    }
+
+    @After
+    public void tearDown() {
+        if (s.isRunning()) {
+            s.stop();
+        }
     }
 }

--- a/mariaDB4j-springboot/src/test/java/ch/vorburger/mariadb4j/tests/springframework/MariaDB4jSpringServiceTestSpringConfiguration.java
+++ b/mariaDB4j-springboot/src/test/java/ch/vorburger/mariadb4j/tests/springframework/MariaDB4jSpringServiceTestSpringConfiguration.java
@@ -28,19 +28,22 @@ import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import java.util.Properties;
 
 @Configuration
-public class MariaDB4jSpringServiceTestSpringConfiguration extends MariaDB4jSpringService {
-
-    protected void configureMariaDB4jSpringService(
-            @SuppressWarnings("unused") MariaDB4jSpringService mariaDB4jSpringService) {}
+public abstract class MariaDB4jSpringServiceTestSpringConfiguration {
 
     @Bean
-    PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
+    public MariaDB4jSpringService mariaDB4jSpringService() {
+        return new MariaDB4jSpringService();
+    }
+
+    @Bean
+    public static PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
         PropertySourcesPlaceholderConfigurer ppc = new PropertySourcesPlaceholderConfigurer();
         Properties properties = new Properties();
         configureProperties(properties);
         ppc.setProperties(properties);
+        ppc.setLocalOverride(true); // Ensure test properties override others
         return ppc;
     }
 
-    protected void configureProperties(@SuppressWarnings("unused") Properties properties) {}
+    protected static void configureProperties(Properties properties) {}
 }


### PR DESCRIPTION
Fixes https://github.com/MariaDB4j/MariaDB4j/issues/1150

The problem 
---
was in the MariaDB4jSpringService class. The setDefaultPort method 
was not being picked up by the `@Value("${" + MariaDB4jSpringService.PORT + ":-1}")` injection because `@Value` was evaluated before the test-specific configuration is applied. That’s why the builder falls back to a random open port instead of the configured one.

