### PR TITLE
clean: Remove openEmbeddedDB(int port) [but keep DBConfiguration variant]

### DIFF
--- a/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
+++ b/mariaDB4j-core/src/main/java/ch/vorburger/mariadb4j/DB.java
@@ -2,7 +2,7 @@
  * #%L
  * MariaDB4j
  * %%
- * Copyright (C) 2012 - 2017 Michael Vorburger
+ * Copyright (C) 2012 - 2025 Michael Vorburger
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,21 +93,6 @@ public class DB {
         DB db = new DB(config);
         db.prepareDirectories();
         return db;
-    }
-
-    /**
-     * This factory method is the mechanism for opening an existing embedded database for use. This
-     * method assumes that the database has already been prepared for use with default
-     * configuration, allowing only for specifying port.
-     *
-     * @param port the port to start the embedded database on
-     * @return a new DB instance
-     * @throws ManagedProcessException if something fatal went wrong
-     */
-    public static DB openEmbeddedDB(int port) throws ManagedProcessException {
-        DBConfigurationBuilder config = DBConfigurationBuilder.newBuilder();
-        config.setPort(port);
-        return openEmbeddedDB(config.build());
     }
 
     /**


### PR DESCRIPTION
Remove again the overloaded 2nd method that was (just) introduced in #1166 for #1042.

The `openEmbeddedDB(DBConfiguration config)` variant makes sense - and is used in the `testEmbeddedMariaDB4jReopenExisting()`.

But I'm not sure that I understand what/when/how the `openEmbeddedDB(int port)` API would ever be used for... especially since #1145, isn't that... (almost) "impossible" to be useful in reality? As in, the directory paths would always be different anyways... unless you re-used literally the exact same identical Java object, which... isn't that kind of pointless then? (My understanding is that the interest of this in practice is to use it ACROSS different JVM starts, with paths that have been fixed by other means of configuration.)

I thought about this more only after merging #1166 (and didn't want to hold that long overdue PR up just because of this).

@xtianus @Muta-Jonathan @Osiris-Team @TheKnowles @wuxindao do any of you have any objection to this PR which (already) removes the `openEmbeddedDB(int port)` API variant again? (We would **_keep_** the other `DB openEmbeddedDB(DBConfiguration config)` variant - obviously.)