### PR TITLE
Moved datadir resuse behind existing newEmbeddedDB() call

### DIFF
--- a/mariaDB4j/src/test/java/ch/vorburger/mariadb4j/tests/MariaDB4jSampleTutorialTest.java
+++ b/mariaDB4j/src/test/java/ch/vorburger/mariadb4j/tests/MariaDB4jSampleTutorialTest.java
@@ -225,9 +225,8 @@ public class MariaDB4jSampleTutorialTest {
             qr.update(conn, "INSERT INTO hello VALUES ('Hello, world')");
             DbUtils.closeQuietly(conn);
             db.stop();
-            // Now reopen the existing DB instance with the "open" method so that the existing data
-            // is preserved
-            DB reopenedDb = DB.openEmbeddedDB(config.build());
+            // Now reopen the existing DB instance so that the existing data is preserved
+            DB reopenedDb = DB.newEmbeddedDB(config.build());
             reopenedDb.start();
             conn = DriverManager.getConnection(db.getConfiguration().getURL(dbName), "root", "");
             List<String> results =


### PR DESCRIPTION
Removed openEmbeddedDB() to avoid client code needing to be aware of data directory reuse.
Reusing temporary directories will require setting isDeletingTemporaryBaseAndDataDirsOnShutdown.