### PR TITLE
Align JUnit Platform with JUnit Jupiter 6.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,8 +172,23 @@
     </plugins>
   </build>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>6.1.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>


### PR DESCRIPTION
Companion fix for #1370.

The engine upgrade was running JUnit Jupiter 6.1.1 against JUnit Platform 1.12.2 inherited from Spring Boot, which fails during test discovery.

This change:
- imports the JUnit 6.1.1 BOM ahead of the Spring Boot BOM;
- adds the JUnit Platform launcher explicitly so every module uses the same 6.1.1 platform line;
- changes no production source.

Verification:
- `./mvnw --show-version --batch-mode --strict-checksums verify`
- all 7 reactor modules passed;
- Maven plugin invoker integration tests passed 3/3;
- the dependency tree resolves Jupiter, engine, launcher, and platform components to 6.1.1.