### PR TITLE
Align JUnit 6 test platform

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
     <project.build.outputTimestamp>2026-01-02T23:14:18Z</project.build.outputTimestamp>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Only use version properties for BOMs or if a version is used across multiple dependencies; otherwise, inline. -->
+    <junit.version>6.1.1</junit.version>
     <springboot.version>3.5.13</springboot.version>
   </properties>
 
@@ -89,7 +90,7 @@
           <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>6.1.1</version>
+            <version>${junit.version}</version>
           </dependency>
         </dependencies>
       </plugin>
@@ -175,6 +176,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${junit.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${springboot.version}</version>
@@ -218,4 +226,12 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 </project>


### PR DESCRIPTION
Companion fix for #1370.

Dependabot upgrades `junit-jupiter-engine` to 6.1.1, while the Spring Boot 3.5.13 BOM still manages the rest of the JUnit stack at 5.12.2 / Platform 1.12.2. Surefire rejects that mixed classpath before running the `mariaDB4j` tests.

This keeps the requested JUnit 6.1.1 upgrade and aligns the complete test stack by:

- importing the JUnit 6.1.1 BOM ahead of Spring Boot's BOM; and
- putting the matching JUnit Platform launcher on the inherited test classpath.

No production source or runtime dependency changed.

Proof:

- Base before Dependabot: `999f173219ebf0f3514d5d02564b40f589425920`
- Dependabot head tested: `7c94fc27d14c54aa5a977ebbd6c8898743f76875`
- The exact Dependabot head reproduces Surefire's conflicting-version failure (`junit-jupiter-engine` 6.1.1 versus Platform 1.12.2) before the affected tests run.
- `./mvnw --batch-mode --strict-checksums -pl mariaDB4j -am clean test` passes the repaired head: 22 tests, 0 failures/errors (1 existing skip).
- A fresh unprivileged Linux/JDK 17 run passed the repository's exact CI sequence:
  - `./mvnw --batch-mode -f DBs/mariaDB4j-db-11.8.6/mariaDB4j-db-winx64-11.8.6/pom.xml clean install`
  - `./mvnw --show-version --batch-mode --strict-checksums verify`
- Full result: all 7 reactor modules passed; 34 tests passed with 0 failures/errors (1 existing skip); all 3 Maven Invoker projects passed.
