### PR TITLE
build: Change mariaDB4j-db-winx64-11.8.6 parent POM from 2.2.2 to 2.3.0

### DIFF
--- a/DBs/mariaDB4j-db-11.8.6/mariaDB4j-db-winx64-11.8.6/pom.xml
+++ b/DBs/mariaDB4j-db-11.8.6/mariaDB4j-db-winx64-11.8.6/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ch.vorburger.mariaDB4j</groupId>
     <artifactId>mariaDB4j-pom-lite</artifactId>
-    <version>2.2.2</version>
+    <version>2.3.0</version>
     <relativePath>../../../mariaDB4j-pom-lite/pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
Required for #1353, see #1317.