### PR TITLE
ci: switch setup-java distribution from adopt to temurin for Windows and macOS

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
-          distribution: adopt
+          distribution: temurin
           java-version-file: .java-version
           cache: maven
       - uses: ankane/setup-mariadb@6caf5fe71e6d7165cd21ca2dcfe5b1d023286795 # v1 as of 2026-03-30, required for 11.8 support
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
-          distribution: adopt
+          distribution: temurin
           java-version-file: .java-version
           cache: maven
       # Build the new Windows 11.8.6 DB package (includes mysqladmin.exe for graceful shutdown)


### PR DESCRIPTION
In `actions/setup-java` v6, support for the legacy `adopt` distribution was removed. `.github/workflows/test.yaml` already used `temurin` on Linux; this PR aligns Windows and macOS to also use `temurin`, resolving build failures when bumping `actions/setup-java` to v6 in #1390.